### PR TITLE
playback: fix value clamping in volumeUp()

### DIFF
--- a/RfidShelf/ShelfPlayback.cpp
+++ b/RfidShelf/ShelfPlayback.cpp
@@ -160,9 +160,10 @@ void ShelfPlayback::volume(uint8_t volume) {
 }
 
 void ShelfPlayback::volumeUp() {
-  _volume -= 5;
-  if(_volume < 0) {
+  if(_volume < 5) {
     _volume = 0;
+  } else {
+    _volume -= 5;
   }
   _musicPlayer.setVolume(_volume, _volume);
 }


### PR DESCRIPTION
The `_volume` member is a `uint8_t` - so it's unsigned. Decreasing the value and only after then checking for below zero isn't gonna work as desired. Fixing that.